### PR TITLE
🚨 Fix linter warnings for manual-list-comprehension

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,4 +50,4 @@ jobs:
 
     - name: Lint with ruff
       run: |
-        poetry run ruff check --ignore ANN001,ANN201,PERF401
+        poetry run ruff check --ignore ANN001,ANN201

--- a/sploty/audio_features.py
+++ b/sploty/audio_features.py
@@ -1,6 +1,7 @@
 import json
 import time
 from http import HTTPStatus
+from itertools import batched
 from pathlib import Path
 
 import pandas as pd
@@ -50,23 +51,6 @@ SPOTIFY_HEADERS = {"Authorization": f"Bearer {ACCESS_TOKEN}"}
 DB_PATH = CONFIG["tinydb"]["track_audio_features"]
 DB = TinyDB(DB_PATH)
 
-# TODO factorize code (enrich.py)
-
-
-def chunks_iter(iterable, chunk_size):
-    """Yield successive n-sized chunks from iter."""
-    iterable = iter(iterable)
-    while True:
-        chunk = []
-        try:
-            for _ in range(chunk_size):
-                chunk.append(next(iterable))
-            yield chunk
-        except StopIteration:
-            if chunk:
-                yield chunk
-            break
-
 
 def do_spotify_request(url, headers, params=None):
     try:
@@ -99,7 +83,7 @@ def inserts_in_db(db, data):
 
 
 def inserts_enriched_tracks(db, tracks_uri, chunk_size):
-    for chunk in chunks_iter(tracks_uri, chunk_size):
+    for chunk in batched(tracks_uri, chunk_size):
         track_audio_features = get_track_audio_features(chunk)
         track_audio_features_without_none_value = [taf for taf in track_audio_features if taf]
         inserts_in_db(db, track_audio_features_without_none_value)

--- a/sploty/enrich.py
+++ b/sploty/enrich.py
@@ -2,6 +2,7 @@ import json
 import time
 from enum import Enum
 from http import HTTPStatus
+from itertools import batched
 from pathlib import Path
 
 import numpy as np
@@ -59,21 +60,6 @@ class BoldColor(str, Enum):
     BOLD = "\033[1m"
     UNDERLINE = "\033[4m"
     END = "\033[0m"
-
-
-def chunks_iter(iterable, chunk_size):
-    """Yield successive n-sized chunks from iter."""
-    iterable = iter(iterable)
-    while True:
-        chunk = []
-        try:
-            for _ in range(chunk_size):
-                chunk.append(next(iterable))
-            yield chunk
-        except StopIteration:
-            if chunk:
-                yield chunk
-            break
 
 
 def do_spotify_request(url, headers, params=None):
@@ -177,7 +163,7 @@ def better_enrich(df_tableau):
     dict_all = {}
     target = len(df)
     checkpoint = 0
-    for rows in chunks_iter(df.iterrows(), CHUNK_SIZE):
+    for rows in batched(df.iterrows(), CHUNK_SIZE):
         logger.info(
             BoldColor.PURPLE
             + "["


### PR DESCRIPTION
- the ruff linter warns about an manual-list-comprehension issue ([PERF401](https://docs.astral.sh/ruff/rules/manual-list-comprehension/))
- a solution for this case is to use [`itertools.batched`](https://docs.python.org/3.12/library/itertools.html#itertools.batched) from Python 3.12
