### PR TITLE
➖ Remove pydantic-argparse dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.12"
 dependencies = [
     "elasticsearch>=8.15.1",
     "pandas>=2.2.3",
-    "pydantic-argparse>=0.9.0",
     "pydantic-settings>=2.6.0",
     "requests>=2.32.3",
     "spotipy>=2.24.0",

--- a/sploty/app.py
+++ b/sploty/app.py
@@ -2,29 +2,33 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pydantic_argparse
-from pydantic import Field, HttpUrl, v1
+from pydantic import Field, HttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from sploty import audio_features, concat, enrich, filter, metrics, to_elastic
 from sploty.settings import logger
 
 
-class Arguments(v1.BaseModel):
-    resources_path: str = v1.Field(description="a required string")
-    previous_enriched_streaming_history_path: str = v1.Field(None, description="an optional string")
-    chunk_size: int = v1.Field(default=100, description="an optional int")
-    spotify_timeout: int = v1.Field(default=10, description="an optional int")
-    spotify_sleep: int = v1.Field(default=60, description="an optional int")
-    db_path: str = v1.Field(description="a required string")
-    index_name: str = v1.Field(description="a required string")
-    elastic_timeout: int = v1.Field(default=10, description="an optional int")
-    concat: bool = v1.Field(default=True)
-    filter: bool = v1.Field(default=True)
-    enrich: bool = v1.Field(default=True)
-    feature: bool = v1.Field(default=True)
-    metric: bool = v1.Field(default=True)
-    elastic: bool = v1.Field(default=True)
+class Arguments(BaseSettings, cli_implicit_flags=True, cli_enforce_required=True):
+    model_config = SettingsConfigDict(cli_parse_args=True)
+    resources_path: str = Field(alias="resources-path", description="a required string")
+    previous_enriched_streaming_history_path: str | None = Field(
+        alias="previous-enriched-streaming-history-path",
+        default=None,
+        description="an optional string",
+    )
+    chunk_size: int = Field(alias="chunk-size", default=100, description="an optional int")
+    spotify_timeout: int = Field(alias="spotify-timeout", default=10, description="an optional int")
+    spotify_sleep: int = Field(alias="spotify-sleep", default=60, description="an optional int")
+    db_path: str = Field(alias="db-path", description="a required string")
+    index_name: str = Field(alias="index-name", description="a required string")
+    elastic_timeout: int = Field(alias="elastic-timeout", default=10, description="an optional int")
+    concat: bool = Field(alias="concat", default=True)
+    filter: bool = Field(alias="filter", default=True)
+    enrich: bool = Field(alias="enrich", default=True)
+    feature: bool = Field(alias="feature", default=True)
+    metric: bool = Field(alias="metric", default=True)
+    elastic: bool = Field(alias="elastic", default=True)
 
 
 class Environment(BaseSettings):
@@ -39,15 +43,8 @@ class Environment(BaseSettings):
 
 
 def main() -> None:
-    # Create Parser and Parse Args
-    parser = pydantic_argparse.ArgumentParser(
-        model=Arguments,
-        prog="Example Program",
-        description="Example Description",
-        version="0.0.1",
-        epilog="Example Epilog",
-    )
-    args = parser.parse_typed_args()
+    # Parse args and environment vars
+    args = Arguments()
     env = Environment()
 
     # Paths

--- a/uv.lock
+++ b/uv.lock
@@ -181,18 +181,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-argparse"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/68/f67377429bb0fb8718dc841beafd3eade66824fc90de87c31a4d5caa2f68/pydantic_argparse-0.9.0.tar.gz", hash = "sha256:01ed0996102301b1269124fd4dd2677d3909e6d930ab86085552c465c8f3aa79", size = 15731 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/fb/ea4f0f4c67e02396035f0706dcb48b2f0168ab6a2e40e98449c2e83a3bbd/pydantic_argparse-0.9.0-py3-none-any.whl", hash = "sha256:d577b3b5e9628e18fea9d37bfbf12dde380fbc6277ac776a30e28106f2c306aa", size = 25913 },
-]
-
-[[package]]
 name = "pydantic-core"
 version = "2.23.4"
 source = { registry = "https://pypi.org/simple" }
@@ -335,7 +323,6 @@ source = { editable = "." }
 dependencies = [
     { name = "elasticsearch" },
     { name = "pandas" },
-    { name = "pydantic-argparse" },
     { name = "pydantic-settings" },
     { name = "requests" },
     { name = "spotipy" },
@@ -351,7 +338,6 @@ dev = [
 requires-dist = [
     { name = "elasticsearch", specifier = ">=8.15.1" },
     { name = "pandas", specifier = ">=2.2.3" },
-    { name = "pydantic-argparse", specifier = ">=0.9.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "spotipy", specifier = ">=2.24.0" },


### PR DESCRIPTION
Argparse support [command line args](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#command-line-support), `pydantic-argparse` is not useful.